### PR TITLE
skip banned posts when parsing, because they contain no files

### DIFF
--- a/booru/utils/parser.py
+++ b/booru/utils/parser.py
@@ -165,7 +165,7 @@ def parse_image(raw_object: dict):
         data = raw_object["post"]
     images = []
     for i in data:
-        if i["is_banned"] == True: #danbooru takedown requests
+        if i.get("is_banned") == True: #danbooru takedown requests
             continue
         try:
             images.append(i["file_url"])

--- a/booru/utils/parser.py
+++ b/booru/utils/parser.py
@@ -163,13 +163,14 @@ def parse_image(raw_object: dict):
 
     elif "post" in raw_object:
         data = raw_object["post"]
-
-    try:
-        images = [i["file_url"] for i in data]
-
-    except:
-        images = [i["file"]["url"] for i in data]  # furry stuff sigh
-
+    images = []
+    for i in data:
+        if i["is_banned"] == True: #danbooru takedown requests
+            continue
+        try:
+            images.append(i["file_url"])
+        except:
+            images.append(i["file"]["url"]) #furry stuff again
     return images
 
 


### PR DESCRIPTION
Allows get_images to work when encountering banned posts without image files.